### PR TITLE
Fix: change the calculations on sticky nav

### DIFF
--- a/src/js/app/main.js
+++ b/src/js/app/main.js
@@ -216,16 +216,16 @@ define(
       });
     });
 
+      // Add targeted nav functionality to nav
+      UTILS.eachIfExists('.js-targeted-nav', function (i, a) {
+          new TARGETEDNAV({
+              container: $(a)
+          });
+      });
+
     // Add sticky nav functionality to nav
     UTILS.eachIfExists('.js-sticky-nav', function (i, a) {
       new STICKYNAV({
-        container: $(a)
-      });
-    });
-
-    // Add targeted nav functionality to nav
-    UTILS.eachIfExists('.js-targeted-nav', function (i, a) {
-      new TARGETEDNAV({
         container: $(a)
       });
     });

--- a/src/js/app/sticky-nav.js
+++ b/src/js/app/sticky-nav.js
@@ -18,7 +18,7 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
   if(!window.HashChangeEvent) {
       (function() {
           var lastURL = document.URL;
-          window.addEventListener('hashchange', function (event) {
+          window.addEventListener('hashchange', function(event) {
               Object.defineProperty(event, 'oldURL', {enumerable: true, configurable: true, value: lastURL});
               Object.defineProperty(event, 'newURL', {enumerable: true, configurable: true, value: document.URL});
               lastURL = document.URL;
@@ -139,7 +139,7 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
           currentLink.addClass('is-current');
       } else {
           // need to do some searching
-          var clickedLiItem = that.navItems.filter(function(){
+          var clickedLiItem = that.navItems.filter(function() {
               return $(this).children('.c-nav__link').attr('href') === location.href;
           });
 

--- a/src/js/app/sticky-nav.js
+++ b/src/js/app/sticky-nav.js
@@ -13,30 +13,41 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
   var $document = $(document);
   var windowWidth = $window.width();
 
+  // We need to set the old/new URL's manually as a workaround for non-browser support
+  // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onhashchange
+  if(!window.HashChangeEvent)(function(){
+      var lastURL=document.URL;
+      window.addEventListener("hashchange",function(event){
+          Object.defineProperty(event,"oldURL",{enumerable:true,configurable:true,value:lastURL});
+          Object.defineProperty(event,"newURL",{enumerable:true,configurable:true,value:document.URL});
+          lastURL=document.URL;
+      });
+  }());
+
+
   var STICKYNAV = function (options) {
 
     if (!options.container) return false;
 
     this.container = options.container;
+    this.navItems = this.container.find('.c-nav__item');
     this.parent = this.container.parent();
-
+    this.currentURL = document.URL;
     this.isSticky = false;
     this.isCentered = false;
 
     // When there's a sticky nav, URL fragments will scroll the page under the navigation
     // Nudge the scroll by nav height
     $window.on('hashchange', null, { that: this }, this.updateScrollPos);
-    // Also do it on page load if location.hash is set
-    //if (location.hash !== '') UTILS.fontsActive(function() { $window.trigger('hashchange'); });
-
     $window.on('resize', null, { that: this }, this.reset);
     $window.on('scroll', null, { that: this }, this.check);
     $window.on('nav.new-targeted-current', null, { that: this }, this.centerCurrentNav);
 
+    this.container.on('click', '.c-nav__item', { that: this }, this.handleLinkClick);
+
     $window.trigger('resize');
 
     console.info(this);
-
   };
 
   STICKYNAV.prototype.defaults = {
@@ -102,14 +113,51 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
   };
 
   STICKYNAV.prototype.updateScrollPos = function(e) {
-    var that = e.data.that;
-    var scrollPos = $window.scrollTop();
-    var navHeight = that.getNavHeight();
-    var paddingTop = parseInt($(location.hash).css('padding-top'),10);
-    navHeight+= (paddingTop > 0) ? 0 : 20 ;
-    $window.scrollTop(scrollPos - navHeight);
+
+      // only update the scroll position if we're looking
+      // at a new URL/hash
+      if(e.originalEvent.oldURL === e.originalEvent.newURL) {
+          return;
+      }
+
+      var that = e.data.that;
+      var scrollPos = $window.scrollTop();
+      var navHeight = that.getNavHeight();
+      //var paddingTop = parseInt($(e.target.hash || location.hash).css('padding-top'),10);
+      var paddingTop = parseInt($(location.hash).css('padding-top'), 10);
+      navHeight+= (paddingTop > 0) ? 0 : 10 ;
+      $window.scrollTop(scrollPos - navHeight);
+
+      that.resetLinkHighlight(e);
+  };
+
+  STICKYNAV.prototype.resetLinkHighlight = function(e, currentLink) {
+      var that = e.data.that;
+      that.navItems.removeClass('is-current');
+
+      if(currentLink) {
+          currentLink.addClass('is-current');
+      } else {
+          // need to do some searching
+          var clickedLiItem = that.navItems.filter(function(index){
+              return $(this).children('.c-nav__link').attr('href') === location.href;
+          });
+
+          clickedLiItem.addClass('is-current');
+      }
+  };
+
+  STICKYNAV.prototype.handleLinkClick = function(e) {
+      var that = e.data.that;
+
+      that.resetLinkHighlight(e, $(this));
+
+      if(that.currentURL === e.target.href) {
+          e.preventDefault();
+          $(e.target).blur(); // remove the leftover highlight
+      }
+      that.currentURL = e.target.href;
   };
 
   return STICKYNAV;
-
 });

--- a/src/js/app/sticky-nav.js
+++ b/src/js/app/sticky-nav.js
@@ -15,14 +15,16 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
 
   // We need to set the old/new URL's manually as a workaround for non-browser support
   // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onhashchange
-  if(!window.HashChangeEvent)(function(){
-      var lastURL=document.URL;
-      window.addEventListener("hashchange",function(event){
-          Object.defineProperty(event,"oldURL",{enumerable:true,configurable:true,value:lastURL});
-          Object.defineProperty(event,"newURL",{enumerable:true,configurable:true,value:document.URL});
-          lastURL=document.URL;
-      });
-  }());
+  if(!window.HashChangeEvent) {
+      (function() {
+          var lastURL = document.URL;
+          window.addEventListener('hashchange', function (event) {
+              Object.defineProperty(event, 'oldURL', {enumerable: true, configurable: true, value: lastURL});
+              Object.defineProperty(event, 'newURL', {enumerable: true, configurable: true, value: document.URL});
+              lastURL = document.URL;
+          });
+      }());
+  }
 
 
   var STICKYNAV = function (options) {
@@ -113,6 +115,10 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
   };
 
   STICKYNAV.prototype.updateScrollPos = function(e) {
+      var that = e.data.that;
+      var scrollPos = $window.scrollTop();
+      var navHeight = that.getNavHeight();
+      var paddingTop = parseInt($(location.hash).css('padding-top'), 10);
 
       // only update the scroll position if we're looking
       // at a new URL/hash
@@ -120,14 +126,8 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
           return;
       }
 
-      var that = e.data.that;
-      var scrollPos = $window.scrollTop();
-      var navHeight = that.getNavHeight();
-      //var paddingTop = parseInt($(e.target.hash || location.hash).css('padding-top'),10);
-      var paddingTop = parseInt($(location.hash).css('padding-top'), 10);
-      navHeight+= (paddingTop > 0) ? 0 : 10 ;
+      navHeight += (paddingTop > 0) ? 0 : 10 ;
       $window.scrollTop(scrollPos - navHeight);
-
       that.resetLinkHighlight(e);
   };
 
@@ -139,7 +139,7 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
           currentLink.addClass('is-current');
       } else {
           // need to do some searching
-          var clickedLiItem = that.navItems.filter(function(index){
+          var clickedLiItem = that.navItems.filter(function(){
               return $(this).children('.c-nav__link').attr('href') === location.href;
           });
 

--- a/src/js/app/sticky-nav.js
+++ b/src/js/app/sticky-nav.js
@@ -133,13 +133,14 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
 
   STICKYNAV.prototype.resetLinkHighlight = function(e, currentLink) {
       var that = e.data.that;
+      var clickedLiItem;
       that.navItems.removeClass('is-current');
 
       if(currentLink) {
           currentLink.addClass('is-current');
       } else {
           // need to do some searching
-          var clickedLiItem = that.navItems.filter(function() {
+          clickedLiItem = that.navItems.filter(function() {
               return $(this).children('.c-nav__link').attr('href') === location.href;
           });
 

--- a/src/js/app/targeted-nav.js
+++ b/src/js/app/targeted-nav.js
@@ -36,7 +36,6 @@ define(['jquery', 'app/utils'], function ($, UTILS) {
     $window.trigger('scroll');
 
     console.info(this);
-
   };
 
   TARGETEDNAV.prototype.check = function (e) {


### PR DESCRIPTION
Fix for a couple of things on the sticky nav component:

- fix clicked navigation links cutting off the title of the section
- fix wrong/previous section being highlighted

[task] https://app.asana.com/0/534292547840024/602522048786244/f