### PR TITLE
Add learn more to key facts

### DIFF
--- a/src/sass/component/_key-fact.scss
+++ b/src/sass/component/_key-fact.scss
@@ -63,3 +63,7 @@ a.c-key-fact:hover{
     font-size:2em;
   }
 }
+.c-key-fact__learnMoreLink {
+  color:$blue;
+  text-decoration:underline;
+}


### PR DESCRIPTION
Adding a class to make 'Learn more', in a clickable key fact, to look like a link.