### PR TITLE
Prevent image zoom on small screens

### DIFF
--- a/src/sass/core/_mixins.scss
+++ b/src/sass/core/_mixins.scss
@@ -174,8 +174,10 @@
     position:relative;
     img {
       position:absolute;
+      @include mq(small, '+') {
       max-width:none;
       max-height:none;
+      }
       top:$top;
       left:$left;
       transform:$transform;


### PR DESCRIPTION
Added a media query to  the class csstranforms in the mixin called center-image to prevent image zoom (big faces) on small screens.