### PR TITLE
fix: remove sticky hover class on mobile

### DIFF
--- a/src/sass/component/_navigation.scss
+++ b/src/sass/component/_navigation.scss
@@ -95,10 +95,15 @@
         padding-right:$base-spacing/2;
         padding-top:10px;
       }
+      @include mq(medium, '+') {
+        &:hover {
+          border-bottom: 5px solid $blue; // gets around a weird sticky hover issue on mobiles
+        }
+      }
+
       &:hover {
         background-color: $s3;
-        color:$charcoal;
-        border-bottom: 5px solid $blue;
+        color: $charcoal;
       }
     }
     &.is-current {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,8 +1736,8 @@ currently-unhandled@^0.4.1:
     array-find-index "^1.0.1"
 
 "customizr@https://github.com/Modernizr/customizr/tarball/develop":
-  version "1.0.0-alpha"
-  resolved "https://github.com/Modernizr/customizr/tarball/develop#a15f0296a0a2488177085aec4ff42c7aaf5510ef"
+  version "1.0.0"
+  resolved "https://github.com/Modernizr/customizr/tarball/develop#7f45419c18d8fefc1378cd1ca00bd2aa3aa501b5"
   dependencies:
     colors "~1.3.0"
     cross-spawn "~6.0.5"


### PR DESCRIPTION
correct weird issue on mobile where clicking nav item keeps hover state when scrolling

[task] https://app.asana.com/0/537225826752670/778893280016402/f