### PR TITLE
Updates to font and image size on large quotes

### DIFF
--- a/src/pages/02-css-components/05-blockquotes.md
+++ b/src/pages/02-css-components/05-blockquotes.md
@@ -58,7 +58,7 @@ component("blockquote", { "type": "image-quote", "content": "<p>Through being in
 component("blockquote", { "type": "pull-quote", "content": "<p>Through being involved with University of York cycling club I have discovered almost every village, every landmark, every hill, every Yorkshire oddity within a 30-mile radius of York.</p>", "cite":"<p>Madeline, PhD student.</p>", "size": "large"});
 </script>
 <script>
-component("blockquote", { "type": "image-quote", "content": "<p>Through being involved with University of York cycling club I have discovered almost every village, every landmark, every hill, every Yorkshire oddity within a 30-mile radius of York.</p><p>I’ve drunk tea by the riverside at Knaresborough, I’ve eaten chips on the Filey seafront, I’ve watched gliders take off Sutton Bank and I’ve seen the monks wondering the grounds of Ampleforth.</p>", "cite": "<p>Madeline, PhD student. <span class=\"u-link\">Read Madeline's guest blog post</span>.</p>", "image": "../media/madeline-250px.jpg", "imagefloat":"left", "size": "large"});
+component("blockquote", { "type": "image-quote", "content": "<p>Through being involved with University of York cycling club I have discovered almost every village, every landmark, every hill, every Yorkshire oddity within a 30-mile radius of York.</p>", "cite": "<p>Madeline, PhD student. <span class=\"u-link\">Read Madeline's guest blog post</span>.</p>", "image": "../media/madeline-250px.jpg", "imagefloat":"left", "size": "large"});
 </script>
 
 ### Linked blockquotes

--- a/src/sass/component/_blockquotes.scss
+++ b/src/sass/component/_blockquotes.scss
@@ -36,68 +36,10 @@
   // To override underlining
   text-decoration:none;
 }
-.c-blockquote--image-quote {
-  .c-blockquote__content {
-    @include demarginalise;
-    background-color:$c-blockquote--image-quote-background-color;
-    padding:$base-spacing;
-    color:$c-blockquote--image-quote-color;
-    font-family: $font-title;
-  }
-}
-.c-blockquote--pull-quote {
-  overflow:visible;
-  padding-top:$base-spacing/2;
-  .c-blockquote__content {
-    @include font-size(22px, 1.13636364);
-    color:$c-blockquote--pull-quote-color;
-    font-family:$font-title;
-    padding:0 $base-spacing * 1.5;
-    :first-child:before {
-      @include font-size(48px);
-      content: open-quote;
-      position:absolute;
-      top:-$base-spacing/2;
-      left:0;
-    }
-    :last-child:after {
-      @include font-size(48px);
-      content: close-quote;
-      position:absolute;
-      bottom: -35px;
-      padding-left: $base-spacing/2;
-
-    }
-    .o-grid__row--alt1 &,
-    .o-grid__row--alt2 & {
-      color:$c-blockquote__content--alt-1-2-color
-    }
-  }
-  .c-blockquote__cite {
-    padding:0 $base-spacing * 1.5;
-  }
-}
-.c-blockquote--large {
-  .c-blockquote__content {
-    @include font-size(32px, 1.25);
-  }
-  &.c-blockquote--pull-quote {
-    .c-blockquote__content {
-      :before,
-      :after {
-        @include font-size(60px);
-      }
-    }
-  }
-  &.c-blockquote--image-quote {
-    .c-blockquote__content {
-      @include font-size(22px, 1.13636364);
-    }
-  }
-  .c-blockquote__cite {
-    @include font-size(16px, 1.5);
-  }
-
+.c-blockquote__content {
+  @include demarginalise;
+  @include font-size(22px, 1.181818182);
+  position:relative;
 }
 .c-blockquote__image {
   @include round;
@@ -128,9 +70,81 @@
     margin-right:$base-spacing/2;
   }
 }
-.c-blockquote__content {
-  @include demarginalise;
-  position:relative;
+.c-blockquote--image-quote {
+  .c-blockquote__content {
+    @include demarginalise;
+    background-color:$c-blockquote--image-quote-background-color;
+    padding:$base-spacing;
+    color:$c-blockquote--image-quote-color;
+    font-family: $font-title;
+  }
+}
+.c-blockquote--pull-quote {
+  overflow:visible;
+  padding-top:$base-spacing/2;
+  .c-blockquote__content {
+    color:$c-blockquote--pull-quote-color;
+    font-family:$font-title;
+    padding:0 $base-spacing * 1.5;
+    :first-child:before {
+      @include font-size(48px);
+      content: open-quote;
+      position:absolute;
+      top:-$base-spacing/2;
+      left:0;
+    }
+    :last-child:after {
+      @include font-size(48px);
+      content: close-quote;
+      position:absolute;
+      bottom: -35px;
+      padding-left: $base-spacing/2;
+
+    }
+    .o-grid__row--alt1 &,
+    .o-grid__row--alt2 & {
+      color:$c-blockquote__content--alt-1-2-color
+    }
+  }
+  .c-blockquote__cite {
+    padding:0 $base-spacing * 1.5;
+  }
+}
+// Large blockquotes only take effect on medium and larger,
+// otherwise they have default behaviour
+.c-blockquote--large {
+  @include mq(medium, '+') {
+    .c-blockquote__content {
+      @include font-size(32px, 1.25);
+    }
+    &.c-blockquote--pull-quote {
+      .c-blockquote__content {
+        :before,
+        :after {
+          @include font-size(60px);
+        }
+      }
+    }
+    &.c-blockquote--image-quote {
+      .c-blockquote__content {
+      }
+      .c-blockquote__image {
+        height:$c-blockquote--large__image-size;
+        width:$c-blockquote--large__image-size;
+      }
+      .c-blockquote__image + .c-blockquote__content,
+      .c-blockquote__image ~ .c-blockquote__cite {
+        width:50%;
+        width:calc(100% - #{$c-blockquote--large__image-size + ($base-spacing*2.5)});
+      }
+      .c-blockquote__image + .c-blockquote__content:after {
+        top:$c-blockquote--large__image-size/2;
+      }
+    }
+    .c-blockquote__cite {
+      @include font-size(16px, 1.5);
+    }
+  }
 }
 // So that the background doesn't extend behind the image
 // And the citee doesn't float too far to the side

--- a/src/sass/core/_variables.scss
+++ b/src/sass/core/_variables.scss
@@ -182,6 +182,7 @@ $c-block-link-border-color:     lighten($s1,5);
 // Blockquotes
 // component/_blockquotes.scss
 $c-blockquote__image-size:                   120px;
+$c-blockquote--large__image-size:            180px;
 $c-blockquote__image-tiny-ratio:             0.75; // How much should the image shrink on tiny screens?
 $c-blockquote--image-quote-background-color: lighten($teal,10);
 $c-blockquote--image-quote-color:            $light;


### PR DESCRIPTION
I've updated the font and image sizes on large quotes, but made them go back to regular size on small (<640px) and tiny (<480px) screens, as the large text just became too much.

Could you take a look and let me know if they are OK?