### PR TITLE
Set hero gradient back to black

### DIFF
--- a/src/sass/core/_variables.scss
+++ b/src/sass/core/_variables.scss
@@ -367,7 +367,7 @@ $c-main-header__logo-size--small: 152px;
 // component/_hero.scss
 $c-hero-background:                   colour( "grey", 900 );  //$charcoal
 $c-hero__content-color:                colour( "grey", 100 );  //$light;
-$c-hero__caption-background-solid:    colour( "grey", 900 );  //$black
+$c-hero__caption-background-solid:    black;  //$black
 $c-hero__caption-background-alpha:    transparentize($c-hero__caption-background-solid, 0.4);
 $c-hero__caption-background-gradient: linear-gradient(
                                         transparent,


### PR DESCRIPTION
Set hero gradient back to being based on black rather than grey to improve legibility.

From:
![image](https://user-images.githubusercontent.com/6151489/96240179-7eb26c00-0f98-11eb-92f6-d68cba781f62.png)

To:
![image](https://user-images.githubusercontent.com/6151489/96240212-88d46a80-0f98-11eb-9f2d-07eb6ef54098.png)
