### PR TITLE
Add new rich-tag molecule

### DIFF
--- a/src/components/tags/rich-tag-list.mustache
+++ b/src/components/tags/rich-tag-list.mustache
@@ -1,0 +1,5 @@
+<ul class="rich-tag-list">
+  {{#atoms}}
+    {{this}}
+  {{/atoms}}
+</ul>

--- a/src/components/tags/rich-tag.mustache
+++ b/src/components/tags/rich-tag.mustache
@@ -1,0 +1,8 @@
+<li class="rich-tag">
+  {{#icon}}<i aria-hidden class="c-icon c-icon--{{this}} c-icon--2x" ></i>{{/icon}}
+  {{#title}}<p class="rich-tag__title">{{this}}</p>{{/title}}
+  {{#text}}<p class="rich-tag__text">{{this}}</p>{{/text}}
+  {{#content}}
+    {{this}}
+  {{/content}}
+</li>

--- a/src/pages/02-css-components/41-rich-tag.md
+++ b/src/pages/02-css-components/41-rich-tag.md
@@ -1,0 +1,60 @@
+---
+
+title: Rich tags
+name: rich-tag
+category: components
+subcategory: Molecules
+layout: q+tq
+id: rich-tag-page
+
+---
+
+<div class="lead"><p>**Rich Tags** are a way for you to link multiple pieces of information in a uniform way.</p></div>
+
+<script>
+component("rich-tag", {
+  "icon": "plane",
+  "title": "Award",
+  "text": "BSc (Hons)"
+});
+</script>
+
+If you have a bunch of them, put them in a list:
+
+<script>
+component("rich-tag-list", { "atoms": [
+  { "rich-tag": {
+    "icon": "mortar-board",
+    "title": "Creativity",
+    "text": "Very creative"
+  }},
+  { "rich-tag": {
+    "icon": "plane",
+    "title": "Culture",
+    "text": "In spades"
+  }},
+  { "rich-tag": {
+    "icon": "bomb",
+    "title": "Environment",
+    "text": "Green and healthy"
+  }}
+]});
+</script>
+
+As the rich tags don't have any special styling, you can put any content in them. An icon list with a title works well 
+for displaying lots of information.
+
+### Options
+
+#### Atoms
+
+* **rich-tag**
+  * **title** - The tag title - recommended
+  * **text** - The text under the tag title - optional
+  * **icon** - an icon to represent it - optional
+  * **content** - other custom content - an icon list would be good.
+
+#### Molecules
+
+* **rich-tag-list**
+  * **atoms**: an array of _rich-tags_

--- a/src/sass/component/_rich_tag.scss
+++ b/src/sass/component/_rich_tag.scss
@@ -1,0 +1,43 @@
+.rich-tag-list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin: 0 0 20px;
+  padding: 0;
+}
+
+.rich-tag {
+  box-sizing: border-box;
+  background-color: $rich-tag-background-color;
+  text-transform: capitalize;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  margin: 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  max-width: 23%;
+  flex: 1 1 206px;
+  @include mq('small', '-') {
+    max-width: 48%;
+  }
+  @include mq('medium', '~') {
+    max-width: 31%;
+  }
+}
+
+.rich-tag__title {
+  font-family: museo-sans, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0; /* for paragraphs */
+}
+
+.rich-tag__text {
+  font-size: 14px;
+  font-size: 0.875rem;
+  margin: 0;
+  line-height: 1.45;
+}

--- a/src/sass/core/_variables.scss
+++ b/src/sass/core/_variables.scss
@@ -582,6 +582,10 @@ $c-tag-background-color-alt2-hover: colour( "pink", 600 ); //darken($pink,25);
 $c-tag-color:                       colour( "grey", 100 );  //$light
 $c-tag-color-hover:                 colour( "grey", 200 );  //darken($light,5)
 
+// Rich tag
+// component/_tag.scss
+$rich-tag-background-color: colour("beige", 100);
+
 // Utility navigation
 // component/_utility-nav.scss
 $c-utility-nav__link-color:                    colour( "grey", 900 );  //$charcoal


### PR DESCRIPTION
This PR adds a new "rich tag" molecule that has been designed during the development of the new Course Search application. It was written by Richard Allum (who is on leave w/c 23/11/2020). He noted that:

> ...direct pixel values will also need replacing with variables. The reason this has not yet been done is that the local build server does not compile css on my machine, so the only changes made to reflect the use of sass so far are the breakpoint mixins.

so feel free to make edits/suggestions as appropriate.