### PR TITLE
Changed justification of image group items

### DIFF
--- a/src/sass/component/_image-group.scss
+++ b/src/sass/component/_image-group.scss
@@ -2,7 +2,7 @@
     align-items: center;
     display: flex;
     flex-wrap: wrap;
-    justify-content: center; 
+    justify-content: space-around; 
     margin: 2em  0;
 }
 


### PR DESCRIPTION
Change justify-content from 'center' to 'space-around' so image group items are more evenly distributed on a row

Using [https://yorkfestivalofideas.com/2021/calendar/gift/](https://yorkfestivalofideas.com/2021/calendar/gift/) as an example:

With `justify-content: center;`
<img width="863" alt="Screenshot 2021-08-06 at 16 51 44" src="https://user-images.githubusercontent.com/6151489/128537622-ea48cd4f-4049-48f8-9691-ab84e7d2e6cc.png">


With `justify-content: space-around;`
<img width="875" alt="Screenshot 2021-08-06 at 16 50 43" src="https://user-images.githubusercontent.com/6151489/128537470-d8963aa7-0e71-4f13-82cd-5b59b1dc5245.png">
